### PR TITLE
fixing vpn-status path in comment

### DIFF
--- a/polybar/vpn-status
+++ b/polybar/vpn-status
@@ -1,5 +1,5 @@
 #!/bin/bash
-# ~/.config/polybar/network-status
+# ~/.config/polybar/vpn-status
 # Script for displaying vpn status as a polybar module
 
 if pgrep -x openvpn; then

--- a/polybar/vpn-status-detailed
+++ b/polybar/vpn-status-detailed
@@ -1,6 +1,6 @@
 #!/bin/bash
-# ~/.config/polybar/network-status
-# Script for displaying vpn status as a polybar module
+# ~/.config/polybar/vpn-status-detailed
+# Script for displaying (detailed) vpn status as a polybar module
 
 if pgrep -x openvpn; then
     notify-send -u low "VPN" "UP" -t 10000


### PR DESCRIPTION
Updated `vpn-status` and `vpn-status-detailed` to have appropriate paths in comment sections.