### PR TITLE
fix setting hostname to include hostnamectl

### DIFF
--- a/src/scripts/install-arch.sh
+++ b/src/scripts/install-arch.sh
@@ -642,7 +642,7 @@ if [ "$?" -ne 0 ]; then
 fi
 
 print_subsec "Setting system hostname..."
-if ! echo '{{ installer.hostname }}' > /mnt/etc/hostname && $chroot hostname '{{ installer.hostname }}' >> install-arch.log 2>&1; then
+if ! echo '{{ installer.hostname }}' > /mnt/etc/hostname && $chroot hostnamectl hostname '{{ installer.hostname }}' >> install-arch.log 2>&1; then
     print_nosubsec_err "Error: Unable to set system hostname - {{ n0ec }}"
     exit $EC
 fi


### PR DESCRIPTION
`arch-chroot /mnt hostname 'example-hostname'` will error out because `hostnamectl` command wasn't included. `hostnamectl` is part of the `systemd` package suite, so package dependencies shouldn't be a concern.